### PR TITLE
refactor: update logging mechanism and simulation initialization for …

### DIFF
--- a/src/js/simulationManager.js
+++ b/src/js/simulationManager.js
@@ -523,7 +523,7 @@ export function enableScheduledLSTMFlood(viewer, predictions = [], durationHours
   });
 
   const activeByName = new Map(); // key -> { start: JulianDate, end: JulianDate, baseHeight, riseRateMps, totalRiseM }
-  const loggedStartByName = new Map(); // key -> last start logged
+  const loggedKeys = new Set(); // key -> logged once per date
 
   const onTick = function(clock) {
     const now = clock.currentTime;
@@ -544,8 +544,9 @@ export function enableScheduledLSTMFlood(viewer, predictions = [], durationHours
       
       // Start jika belum aktif atau sudah lewat dari window sebelumnya
       if (!active || Cesium.JulianDate.greaterThan(now, active.end)) {
-        const start = now.clone();
-        const end = Cesium.JulianDate.addHours(start, durationHours, new Cesium.JulianDate());
+        // Gunakan start window tetap (12:00) agar scrub timeline konsisten
+        const start = currentWindow.start.clone();
+        const end = currentWindow.end.clone();
         
         // Gunakan entity pertama sebagai referensi untuk perhitungan global
         const referenceEntity = waterLevelEntities[0];
@@ -589,16 +590,14 @@ export function enableScheduledLSTMFlood(viewer, predictions = [], durationHours
 
         activeByName.set(currentWindow.key, { start, end, baseHeight, riseRateMps, totalRiseM });
 
-        // Logging ke console & kirim ke UI tabel log (hindari duplikat untuk event yang sama)
+        // Logging ke console & kirim ke UI tabel log (sekali saja per tanggal)
         try {
           const riseM = totalRiseM;
           const riseCm = riseM * 100;
           const hBaru = baseHeight + riseM;
           const startDate = Cesium.JulianDate.toDate(start);
-          const lastLoggedIso = loggedStartByName.get(currentWindow.key);
-          const thisIso = startDate.toISOString();
           
-          if (lastLoggedIso !== thisIso) {
+          if (!loggedKeys.has(currentWindow.key)) {
             console.log(
               `[START FLOOD LSTM] Date: ${currentWindow.key} | maxMm=${currentWindow.mm.toFixed(2)} | baseHeight=${baseHeight.toFixed(2)} m | ` +
               `rate=${riseRateMps.toFixed(5)} m/s | riseM=${riseM.toFixed(5)} m | riseCm=${riseCm.toFixed(2)} cm | ` +
@@ -607,7 +606,7 @@ export function enableScheduledLSTMFlood(viewer, predictions = [], durationHours
 
             window.dispatchEvent(new CustomEvent('floodStartLog', {
               detail: {
-                timestampIso: thisIso,
+                timestampIso: startDate.toISOString(),
                 name: 'GLOBAL (LSTM)',
                 maxMm: currentWindow.mm,
                 baseHeight,
@@ -617,7 +616,7 @@ export function enableScheduledLSTMFlood(viewer, predictions = [], durationHours
                 durationHours
               }
             }));
-            loggedStartByName.set(currentWindow.key, thisIso);
+            loggedKeys.add(currentWindow.key);
           }
         } catch(_) { /* noop */ }
       }
@@ -642,7 +641,6 @@ export function enableScheduledLSTMFlood(viewer, predictions = [], durationHours
           removeRainEffectForKecamatan(viewer.scene);
           
           activeByName.delete(key);
-          loggedStartByName.delete(key);
           console.log(`[LSTM] Menghentikan simulasi global untuk ${key}.`);
         }
       }
@@ -670,7 +668,7 @@ export function enableScheduledLSTMFlood(viewer, predictions = [], durationHours
     removeRainEffectForKecamatan(viewer.scene);
     
     activeByName.clear();
-    loggedStartByName.clear();
+    loggedKeys.clear();
     console.log("Scheduled LSTM flood simulation stopped.");
   };
 }

--- a/src/js/uiControl/lstmControls.js
+++ b/src/js/uiControl/lstmControls.js
@@ -66,6 +66,24 @@ export function initializeLSTMUIControls(viewer) {
           viewer.clock.stopTime = stopTime;
           viewer.clock.clockRange = Cesium.ClockRange.UNBOUNDED;
           
+          // Cari jendela hujan pertama (prediksi dengan nilai > 0) dan arahkan currentTime ke jam 12:00 tanggal tsb
+          const firstWet = predictions.find(p => Number(p?.value || 0) > 0);
+          if (firstWet && firstWet.date) {
+            const firstWetDateLocalNoon = new Date(firstWet.date + 'T12:00:00');
+            const firstWetJulian = Cesium.JulianDate.fromDate(firstWetDateLocalNoon);
+            // Pastikan masih di dalam rentang yang sudah di-set
+            if (Cesium.JulianDate.greaterThanOrEquals(firstWetJulian, viewer.clock.startTime) && Cesium.JulianDate.lessThanOrEquals(firstWetJulian, viewer.clock.stopTime)) {
+              viewer.clock.currentTime = firstWetJulian.clone();
+            }
+          }
+          
+          // Aktifkan animasi agar onTick scheduler berjalan saat user scrub/biarkan play
+          viewer.clock.shouldAnimate = true;
+          // Multiplier sedang agar transisi terlihat namun tetap cepat menjangkau jendela berikutnya
+          if (!viewer.clock.multiplier || viewer.clock.multiplier < 60) {
+            viewer.clock.multiplier = 600; // 10 menit per detik
+          }
+          
           // Zoom timeline ke range yang sesuai
           viewer.timeline.zoomTo(startTime, stopTime);
           


### PR DESCRIPTION
…LSTM flood

- Replaced the logged start tracking from a Map to a Set to prevent duplicate logging of flood events per date.
- Adjusted the simulation start time to use a fixed window for consistency in timeline scrubbing.
- Enhanced the initialization of the viewer's clock to set the current time to the first wet prediction at noon, improving user experience during simulations.